### PR TITLE
how to render from rstudio, r console, and terminal

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -50,6 +50,44 @@ To create a [reveal.js](http://lab.hakim.se/reveal-js/#/) presentation from R Ma
     - Get in bed
     - Count sheep
 
+## Rendering 
+
+Depening on your use case, there are 3 ways you can render the presentation.
+
+1. RStudio
+2. R console
+3. Terminal (e.g., bash)
+
+### RStudio
+
+When creating the presentation in RStudio, there will be a `Knit` button
+right below the source tabs.
+By default, it will render the current document and place the rendered `HTML` file in the same directory as the source file, with the same name.
+
+Note: Unlike the the other slideshow outputs, the slideshow viewer popup from rstudio will be blank,
+to view the slide show click the `open in browser` button,
+and the slide show will render in your default web browser.
+
+### R Console
+
+The `Knit` button is actually calling the `rmarkdown::render()` function.
+So, to render the doucment within the R console:
+
+```r
+rmarkdown::render('my_reveal_presentation.Rmd')
+```
+
+There are many other output tweaks you can use by directly calling `render`.
+You can read up on the [documentation](https://cran.r-project.org/web/packages/rmarkdown/rmarkdown.pdf) for more details.
+
+### Command Line
+
+When you need the presentation to be rendered from the command line:
+
+```bash
+Rscript -e "rmarkdown::render('my_reveal_presentation.Rmd')"
+```
+
 ## Display Modes
 
 The following single character keyboard shortcuts enable alternate

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ To create a [reveal.js](http://lab.hakim.se/reveal-js/#/) presentation from R Ma
 
 ## Rendering 
 
-Depening on your use case, there are 3 ways you can render the presentation.
+Depending on your use case, there are 3 ways you can render the presentation.
 
 1. RStudio
 2. R console
@@ -64,14 +64,14 @@ When creating the presentation in RStudio, there will be a `Knit` button
 right below the source tabs.
 By default, it will render the current document and place the rendered `HTML` file in the same directory as the source file, with the same name.
 
-Note: Unlike the the other slideshow outputs, the slideshow viewer popup from rstudio will be blank,
+Note: Unlike the the other slideshow outputs, the slideshow viewer popup from RStudio will be blank,
 to view the slide show click the `open in browser` button,
 and the slide show will render in your default web browser.
 
 ### R Console
 
 The `Knit` button is actually calling the `rmarkdown::render()` function.
-So, to render the doucment within the R console:
+So, to render the document within the R console:
 
 ```r
 rmarkdown::render('my_reveal_presentation.Rmd')

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ R Markdown Format for reveal.js Presentations
 ================
 
 -   [Overview](#overview)
+-   [Rendering](#rendering)
 -   [Display Modes](#display-modes)
 -   [Incremental Bullets](#incremental-bullets)
 -   [Appearance and Style](#appearance-and-style)
@@ -58,6 +59,39 @@ To create a [reveal.js](http://lab.hakim.se/reveal-js/#/) presentation from R Ma
 
     - Get in bed
     - Count sheep
+
+Rendering
+---------
+
+Depening on your use case, there are 3 ways you can render the presentation.
+
+1.  RStudio
+2.  R console
+3.  Terminal (e.g., bash)
+
+### RStudio
+
+When creating the presentation in RStudio, there will be a `Knit` button right below the source tabs. By default, it will render the current document and place the rendered `HTML` file in the same directory as the source file, with the same name.
+
+Note: Unlike the the other slideshow outputs, the slideshow viewer popup from rstudio will be blank, to view the slide show click the `open in browser` button, and the slide show will render in your default web browser.
+
+### R Console
+
+The `Knit` button is actually calling the `rmarkdown::render()` function. So, to render the doucment within the R console:
+
+``` r
+rmarkdown::render('my_reveal_presentation.Rmd')
+```
+
+There are many other output tweaks you can use by directly calling `render`. You can read up on the [documentation](https://cran.r-project.org/web/packages/rmarkdown/rmarkdown.pdf) for more details.
+
+### Command Line
+
+When you need the presentation to be rendered from the command line:
+
+``` bash
+Rscript -e "rmarkdown::render('my_reveal_presentation.Rmd')"
+```
 
 Display Modes
 -------------

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To create a [reveal.js](http://lab.hakim.se/reveal-js/#/) presentation from R Ma
 Rendering
 ---------
 
-Depening on your use case, there are 3 ways you can render the presentation.
+Depending on your use case, there are 3 ways you can render the presentation.
 
 1.  RStudio
 2.  R console
@@ -73,11 +73,11 @@ Depening on your use case, there are 3 ways you can render the presentation.
 
 When creating the presentation in RStudio, there will be a `Knit` button right below the source tabs. By default, it will render the current document and place the rendered `HTML` file in the same directory as the source file, with the same name.
 
-Note: Unlike the the other slideshow outputs, the slideshow viewer popup from rstudio will be blank, to view the slide show click the `open in browser` button, and the slide show will render in your default web browser.
+Note: Unlike the the other slideshow outputs, the slideshow viewer popup from RStudio will be blank, to view the slide show click the `open in browser` button, and the slide show will render in your default web browser.
 
 ### R Console
 
-The `Knit` button is actually calling the `rmarkdown::render()` function. So, to render the doucment within the R console:
+The `Knit` button is actually calling the `rmarkdown::render()` function. So, to render the document within the R console:
 
 ``` r
 rmarkdown::render('my_reveal_presentation.Rmd')


### PR DESCRIPTION
Fixes #27

I added the rendering section after the overview section since the example code/presentation was there.

The only other place was at the very bottom, but I figured right at the beginning would be better.