### PR TITLE
Interpret slide_level in YAML

### DIFF
--- a/R/revealjs_presentation.R
+++ b/R/revealjs_presentation.R
@@ -108,7 +108,8 @@ revealjs_presentation <- function(incremental = FALSE,
   args <- c(args, pandoc_variable_arg("center", jsbool(center)))
   
   # slide level
-  args <- c(args, "--slide-level", "2")
+  if (!is.null(slide_level))
+    args <- c(args, "--slide-level", as.character(slide_level))
   
   # theme
   theme <- match.arg(theme, revealjs_themes())


### PR DESCRIPTION
The pandoc arg `--slide-level` was being set to the default 2 without checking if the user had supplied a value for `slide_level` in the YAML.  This commit will allow the user to set the slide level. 