### PR TITLE
display leaflet in revealjs

### DIFF
--- a/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
@@ -99,6 +99,14 @@ $endif$
 $endif$
 
   </style>
+  
+  <!-- for leaflet -->
+  <style type="text/css">
+    .reveal .leaflet-container img {
+    max-height: none !important;
+    }
+  </style>
+
 
     <style type="text/css">code{white-space: pre;}</style>
 


### PR DESCRIPTION
I love the revealjs package and I always use it.
However, using leaflet with revealjs, MapTiles may not be displayed properly.
That's the cause the style `.reveal img {max-height: 95%}` .

So, I propose a `default.html` to fix this.