### PR TITLE
Fix/quote default variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: revealjs
 Type: Package
 Title: R Markdown Format for 'reveal.js' Presentations
-Version: 0.9
+Version: 0.9.1
 Date: 2017-03-13
 Authors@R: c(
     person("Hakim", "El Hattab", role = c("aut", "cph"),

--- a/R/revealjs_presentation.R
+++ b/R/revealjs_presentation.R
@@ -147,8 +147,13 @@ revealjs_presentation <- function(incremental = FALSE,
     add_reveal_option <- function(option, value) {
       if (is.logical(value))
         value <- jsbool(value)
-      else if (is.character(value))
-        value <- paste0("'", value, "'")
+      else if (is.character(value)) {
+        # Add quotes around some config that can be several type
+        # e.g slideNumber = true or slideNumber = 'c/t'
+        if (option %in% c("slideNumber")) {
+          value <- paste0("'", value, "'")
+        }
+      }
       args <<- c(args, pandoc_variable_arg(option, value))
     }
     

--- a/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
@@ -615,7 +615,7 @@ $if(transition)$
 $endif$
 $if(transitionSpeed)$
         // Transition speed
-        transitionSpeed: $transitionSpeed$, // default/fast/slow
+        transitionSpeed: '$transitionSpeed$', // default/fast/slow
 $endif$
 $if(backgroundTransition)$
         // Transition style for full page slide backgrounds
@@ -627,19 +627,19 @@ $if(viewDistance)$
 $endif$
 $if(parallaxBackgroundImage)$
         // Parallax background image
-        parallaxBackgroundImage: $parallaxBackgroundImage$, // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
+        parallaxBackgroundImage: '$parallaxBackgroundImage$', // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
 $endif$
 $if(parallaxBackgroundSize)$
         // Parallax background size
-        parallaxBackgroundSize: $parallaxBackgroundSize$, // CSS syntax, e.g. "2100px 900px"
+        parallaxBackgroundSize: '$parallaxBackgroundSize$', // CSS syntax, e.g. "2100px 900px"
 $endif$
 $if(parallaxBackgroundHorizontal)$
         // Amount to move parallax background (horizontal and vertical) on slide change
         // Number, e.g. 100
-        parallaxBackgroundHorizontal: $parallaxBackgroundHorizontal$,
+        parallaxBackgroundHorizontal: '$parallaxBackgroundHorizontal$',
 $endif$
 $if(parallaxBackgroundVertical)$
-        parallaxBackgroundVertical: $parallaxBackgroundVertical$,
+        parallaxBackgroundVertical: '$parallaxBackgroundVertical$',
 $endif$
 $if(width)$
         // The "normal" size of the presentation, aspect ratio will be preserved

--- a/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
@@ -531,7 +531,7 @@ $body$
   <script>
 
       // Full list of configuration options available at:
-      // https://github.com/hakimel/reveal.js#configuration
+      // https://revealjs.com/config/
       Reveal.initialize({
 $if(controls)$
         // Display controls in the bottom right corner
@@ -543,6 +543,14 @@ $if(progress)$
 $endif$
 $if(slideNumber)$
         // Display the page number of the current slide
+        // - true:    Show slide number
+        // - false:   Hide slide number
+        //
+        // Can optionally be set as a string that specifies the number formatting:
+        // - "h.v":   Horizontal . vertical slide number (default)
+        // - "h/v":   Horizontal / vertical slide number
+        // - "c":   Flattened slide number
+        // - "c/t":   Flattened slide number / total slides
         slideNumber: $slideNumber$,
 $endif$
 $if(history)$


### PR DESCRIPTION
Following the fix 633c05f47dca23c48382804bd8d0cf9d55d018bb for #72 , there was an issue with Pandoc 2.14.0.3 and later because of a change in the way variables are set (see #90) 

As Pandoc is setting some variables directly with default value, if required the quotes needs to be in the template directly.

So this PR is another way to fix #72. Basically, the double quotes are introduced because of 
https://github.com/rstudio/revealjs/blob/6b272a7e188067c19bacac6b3f69713b8f25cba5/R/revealjs_presentation.R#L147-L153
Any character value option will be quoted by R before being passed to Pandoc as variable. This is only useful for some options that can be either quoted (as string e.g `slideNumber = 'c/t'`) or unquoted (as boolean e.g `slideNumber = true`.)

We only add the quotes for known options that needs both. 