### PR TITLE
Add institute variable in template for title slide

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,10 @@
 
 - Add `title-slide` id on the auto generated title slide to ease the styling using CSS.
 
-- Support `background-image` pandoc's variable as other slide framework to customize the option `parallaxBackgroundImage`. This duplicates the variable `parallaxBackgroundImage` which still get precedence.
+- Support more Pandoc's variable in `revealjs_presentation()` as documented in Pandoc for HTML slides:
+* `background-image` to customize the option `parallaxBackgroundImage`. This duplicates the variable `parallaxBackgroundImage` which still get precedence.
+* `institute` to provide another line in title slide between author and date
+* `toc-title` to provide a Title above the toc when `toc = TRUE`
 
 - Fix template to add the necessary CSS to format [columns layout](https://pandoc.org/MANUAL.html#columns) and other Pandoc's features (thanks, @atusy, #82).
 

--- a/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
@@ -543,7 +543,7 @@ $for(author)$
     <h2 class="author">$author$</h2>
 $endfor$
 $for(institute)$
-    <h2 class="institute">$institute$</h2>
+    <h3 class="institute">$institute$</h2>
 $endfor$
 $if(date)$
     <h3 class="date">$date$</h3>

--- a/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
@@ -542,6 +542,9 @@ $endif$
 $for(author)$
     <h2 class="author">$author$</h2>
 $endfor$
+$for(institute)$
+    <h2 class="institute">$institute$</h2>
+$endfor$
 $if(date)$
     <h3 class="date">$date$</h3>
 $endif$


### PR DESCRIPTION
Proposal for #87 

This only add the same variable than in pandoc template: https://github.com/jgm/pandoc-templates/blob/466c90ed5bb489d9cafe41b59fff47a3c5eb858c/default.revealjs#L55-L57

Title slide would look like this with our format currently

Example: 
````markdown
---
title: "Title slide"
author: Christophe
institute: RStudio
date: '`r format(Sys.Date(), "%D")`'
output: revealjs::revealjs_presentation
---

````

![image](https://user-images.githubusercontent.com/6791940/133757038-3a786e26-299d-4635-8123-f23da641788f.png)

With Pandoc's current default using Quarto 0.2.144

````markdown
---
title: "Title slide"
author: Christophe
institute: RStudio
date: '`r format(Sys.Date(), "%D")`'
format: revealjs
---

# Important {data-background="background.jpg"}

This is the first slide.
````

![image](https://user-images.githubusercontent.com/6791940/133757323-bf7a35b6-c53a-4f07-b3bb-4a6baf0a4d3b.png)

Using multiple authors and institues , in both cases it will only pile up the authors, then the institute. 
Do we want something clever than that for the title slide or be close to Pandoc's default ? 

```yaml
title: "Title slide"
author: 
  - Bob
  - Joe
institute: 
  - Great, PBC
  - Good, PBC
date: '`r format(Sys.Date(), "%D")`'
output: revealjs::revealjs_presentation
```

![image](https://user-images.githubusercontent.com/6791940/133759072-8b741145-e0c1-4d2c-88be-f2969dff6cd3.png)

Opening this PR for discussion about this. 

cc @apreshill 
