### PR TITLE
allow toc to overflow

### DIFF
--- a/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/resources/default.html
@@ -65,6 +65,12 @@ $endif$
       margin-left: 2em;
     }
     $endif$
+    $if(toc)$
+    .reveal #$idprefix$TOC {
+      height: 100%;
+      overflow-y: auto;
+    }
+    $endif$
   </style>
 
 $if(theme)$


### PR DESCRIPTION
Current implementation hides TOC when it has too many items.

This PR let TOC be scrollable.

